### PR TITLE
Formatierer und Test-Framework-Einstellungen vereinheitlichen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.autopep8"
+    },
+    "python.formatting.provider": "none",
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        ".",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}


### PR DESCRIPTION
Hallöle Niklas, ich schlage vor wir benutzen die selben VSCode-Einstellungen bezüglich Codeformatierung und Unittesting